### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Hubspot-Inc/org.DolphinEmu.dolphin-emu/security/code-scanning/1](https://github.com/Hubspot-Inc/org.DolphinEmu.dolphin-emu/security/code-scanning/1)

To fix the problem, explicitly set the minimal required `permissions` for the workflow to adhere to the principle of least privilege. Since the shown workflow only checks out code and prints messages—without modifying any repository content or interacting with issues or pull requests—the minimal required permission is `contents: read`. You can set this at the workflow root (which applies to all jobs), or at the job level. The best practice is to place this at the root level, directly after the `name` key and before the `on` key, so all jobs default to these permissions unless overridden.

No new imports, methods, or definitions are needed.

This involves:
- Inserting the following YAML at the workflow root (after `name: CI`):
  ```yaml
  permissions:
    contents: read
  ```
- No other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
